### PR TITLE
Fix Delegate.get_delegate to work with public keys

### DIFF
--- a/lib/ark_elixir/delegate.ex
+++ b/lib/ark_elixir/delegate.ex
@@ -33,7 +33,7 @@ defmodule Ark_Elixir.Delegate do
          "publicKey" => "038dfc041c7e609f254b2cf38de4b55e02dff9e743497f5cf6b67d49d8e44978ce",
          "username" => "drusilla", "vote" => "0"}], "success" => true}
     """
-    def search_delegates(query, opts \\ []) do
+    def search_delegates(query, _opts \\ []) do
         Ark_Elixir.Api.get("api/delegates/search", query)
     end
 
@@ -81,10 +81,11 @@ defmodule Ark_Elixir.Delegate do
         "success" => true}
     """
     def get_delegate(id) do
-      case String.length(id) do
-        66 -> Ark_Elixir.Api.get("api/delegates/get", [publicKey: id])
-        _ -> Ark_Elixir.Api.get("api/delegates/get", [username: id])
+      id_type = case String.length(id) do
+        66 -> :publicKey
+        _ -> :username
       end
+      Ark_Elixir.Api.get("api/delegates/get", [{id_type, id}])
     end
 
 

--- a/lib/ark_elixir/delegate.ex
+++ b/lib/ark_elixir/delegate.ex
@@ -60,7 +60,7 @@ defmodule Ark_Elixir.Delegate do
 
 
     @doc """
-    Get a single delegate.
+    Get a single delegate by name or public key.
 
     ## Examples
 
@@ -71,22 +71,20 @@ defmodule Ark_Elixir.Delegate do
         "publicKey" => "02c7455bebeadde04728441e0f57f82f972155c088252bf7c1365eb0dc84fbf5de",
         "rate" => 35, "username" => "jarunik", "vote" => "141330551085778"},
         "success" => true}
+
+        iex> Ark_Elixir.Delegate.get_delegate("02c7455bebeadde04728441e0f57f82f972155c088252bf7c1365eb0dc84fbf5de")
+        %{"delegate" => %{"address" => "Aasu14aTs9ipZdy1FMv7ay1Vqn3jPskA8t",
+        "approval" => 1.18, "missedblocks" => 227, "producedblocks" => 48565,
+        "productivity" => 99.53,
+        "publicKey" => "02c7455bebeadde04728441e0f57f82f972155c088252bf7c1365eb0dc84fbf5de",
+        "rate" => 4, "username" => "jarunik", "vote" => "154019617402053"},
+        "success" => true}
     """
-    def get_delegate(username) do
-        Ark_Elixir.Api.get("api/delegates/get", [username: username])
-    end
-
-
-    @doc """
-    Get a single delegate.
-
-    ## Examples
-
-        iex> Ark_Elixir.Delegate.get_delegate("arkValidPublicKey")
-        ...
-    """
-    def get_delegate(publicKey) do
-        Ark_Elixir.Api.get("api/delegates/get", [publicKey: publicKey])
+    def get_delegate(id) do
+      case String.length(id) do
+        66 -> Ark_Elixir.Api.get("api/delegates/get", [publicKey: id])
+        _ -> Ark_Elixir.Api.get("api/delegates/get", [username: id])
+      end
     end
 
 

--- a/test/ark_elixir_test.exs
+++ b/test/ark_elixir_test.exs
@@ -136,11 +136,11 @@ defmodule Ark_ElixirTest do
         assert elem(success, 1) == true
     end
 
-    #test "delegate get delegate by publickey" do
-    #    req = Ark_Elixir.Delegate.get_delegate("02c7455bebeadde04728441e0f57f82f972155c088252bf7c1365eb0dc84fbf5de")
-    #    success =  Enum.find(req, fn {key, _} -> key == "success" end)
-    #    assert elem(success, 1) == true
-    #end
+    test "delegate get delegate by publickey" do
+        req = Ark_Elixir.Delegate.get_delegate("02c7455bebeadde04728441e0f57f82f972155c088252bf7c1365eb0dc84fbf5de")
+        success =  Enum.find(req, fn {key, _} -> key == "success" end)
+        assert elem(success, 1) == true
+    end
 
     test "delegate get delegates" do
         req = Ark_Elixir.Delegate.get_delegates


### PR DESCRIPTION
I am attempting to address #1 with this small change. The two get_delegate functions have been merged into one. This function uses a case block to determine if the id passed is a username or public key. It then issues the request with the proper field in either case.